### PR TITLE
Make instruction status into hash set

### DIFF
--- a/radius/Cargo.toml
+++ b/radius/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "radius2"
 description = "a fast symbolic execution framework using r2"
-version = "1.0.10"
+version = "1.0.11"
 authors = ["aemmitt-ns <aemmitt@nowsecure.com>"]
 license = "MIT"
 edition = "2018"

--- a/radius/README.md
+++ b/radius/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/radareorg/radare2.git
 radare2/sys/install.sh 
 ```
 
-Include radius as a dependency using `radius2 = "1.0.8"` or build locally with `cargo build --release`
+Include radius as a dependency using `radius2 = "1.0.11"` or build locally with `cargo build --release`
 
 ### Supported Architectures
 
@@ -56,7 +56,7 @@ fn main() {
 radius can also be installed from crates.io and easily included in packages. radius also has a CLI tool that can be installed with `cargo install radius2`
 
 ```
-radius2 1.0.9
+radius2 1.0.11
 Austin Emmitt (@alkalinesec) <aemmitt@nowsecure.com>
 Symbolic Execution tool using r2 and boolector
 
@@ -64,7 +64,7 @@ USAGE:
     radius2 [FLAGS] [OPTIONS] --path <path>
 
 FLAGS:
-    -F, --frida         Create initial state from frida hook
+    -C, --color         Use color output
     -h, --help          Prints help information
     -z, --lazy          Evaluate symbolic PC values lazily
         --no-sims       Do not simulate imports
@@ -90,8 +90,10 @@ OPTIONS:
     -e, --eval <ESIL>...                      Evaluate ESIL expression
     -E, --eval-after <ESIL>...                Evaluate ESIL expression after execution
     -f, --file <PATH> <SYMBOL>                Add a symbolic file
+    -F, --fuzz <fuzz>                         Generate testcases and write to supplied dir
     -H, --hook <ADDR> <EXPR>                  Hook the provided address with an ESIL expression
     -L, --libs <libs>                         Load libraries from path
+        --max <max>                           Maximum number of states to keep at a time
     -m, --merge <merge>...                    Set address as a mergepoint
     -p, --path <path>                         Path to the target binary
     -r, --r2-cmd <CMD>...                     Run r2 command on launch
@@ -109,6 +111,6 @@ $ radius2 -p tests/r100 -a 0x4006fd -x 0x400790 -s flag 96 str -S A0 0x100000 64
 Or even more quickly with strings using 
 
 ```
-$ radius2 -p tests/r100 -s stdin 96 -X Incorrect
+$ radius2 -p tests/r100 -s stdin 96 str -X Incorrect
   stdin : "Code_Talkers"
 ```

--- a/radius/src/main.rs
+++ b/radius/src/main.rs
@@ -56,6 +56,7 @@ fn main() {
                 .short("L")
                 .long("libs")
                 .takes_value(true)
+                .multiple(true)
                 .help("Load libraries from path"),
         )
         .arg(

--- a/radius/src/operations.rs
+++ b/radius/src/operations.rs
@@ -80,6 +80,7 @@ pub enum Operations {
     ToDo,
     NoOperation,
     Print, // Tool for cli hooks
+    PrintDebug, // Tool for cli hooks
     Constrain,
     Terminate,
 
@@ -183,6 +184,7 @@ impl Operations {
 
             // hax for use in the cli / plugin
             "." => Operations::Print,
+            ".." => Operations::PrintDebug,
             "_" => Operations::Constrain,
             "!!" => Operations::Terminate,
 
@@ -806,6 +808,11 @@ pub fn do_operation(state: &mut State, operation: &Operations) {
             } else {
                 println!("\n{:016x}: unsat\n", ip);
             }
+        }
+        Operations::PrintDebug => {
+            let value = pop_value(state, false, false);
+            let ip = state.registers.get_pc().as_u64().unwrap_or_default();
+            println!("\n{:016x}: {:?}\n", ip, value);
         }
         Operations::Constrain => {
             let value = pop_value(state, false, false);

--- a/radius/src/radius.rs
+++ b/radius/src/radius.rs
@@ -139,7 +139,7 @@ impl Radius {
 
         let mut r2api = R2Api::new(filename, args);
         r2api.set_option("io.cache", "true").unwrap();
-        r2api.cmd("eco darkda").unwrap(); // i like darkda
+        // r2api.cmd("eco darkda").unwrap(); // i like darkda
 
         let arch = &r2api.info.bin.arch;
 


### PR DESCRIPTION
This changes the instruction status property into instruction flags, a hashset of the previous statuses. This will allow addresses to be both hooked and sim'ed etc  