### PR TITLE
Add MIPS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/radius/Cargo.toml
+++ b/radius/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/aemmitt-ns/radius"
 readme = "README.md"
 
 [dependencies]
-r2pipe = "0.7.0"
+r2pipe = { path = "../../r2pipe.rs/" }
 serde_json = "1.0.59"
 serde = { version = "1.0.117", features = ["derive"] }
 boolector = "0.4.3"

--- a/radius/src/r2_api.rs
+++ b/radius/src/r2_api.rs
@@ -542,6 +542,7 @@ impl R2Api {
         r2api
     }
 
+    /// Run a command on the `r2` CLI and return its output.
     pub fn cmd(&mut self, cmd: &str) -> R2Result<String> {
         Ok(self.r2p.lock().unwrap().cmd(cmd).unwrap_or_default())
     }
@@ -988,6 +989,7 @@ impl R2Api {
         r2_result(serde_json::from_str(json.as_str()))
     }
 
+    /// Call into `r2` to disassemble `num` instructions at `addr`.
     pub fn disassemble(&mut self, addr: u64, num: usize) -> R2Result<Vec<Instruction>> {
         let cmd = format!("pdj {} @ {}", num, addr);
         let json = self.cmd(cmd.as_str())?;

--- a/radius/src/radius.rs
+++ b/radius/src/radius.rs
@@ -219,7 +219,7 @@ impl Radius {
         let mut state = self.init_state();
         state.memory.add_stack();
         state.memory.add_heap();
-        state.memory.add_std_streams();
+        //state.memory.add_std_streams();
         state
     }
 

--- a/radius/src/registers.rs
+++ b/radius/src/registers.rs
@@ -113,6 +113,11 @@ impl Registers {
         registers
     }
 
+    /// Returns `true` iff this register is the PC.
+    pub fn is_pc(&self, reg: &Register) -> bool {
+        self.pc.as_ref().unwrap().index == reg.index
+    }
+
     /// Get the value of the register `reg`
     #[inline]
     pub fn get(&self, reg: &str) -> Value {

--- a/radius/src/sims/syscall.rs
+++ b/radius/src/sims/syscall.rs
@@ -301,8 +301,8 @@ pub fn sbrk(state: &mut State, args: &[Value]) -> Value {
 // will result in a split state when used to branch
 // essentially recreating a fork. pretty cool!
 pub fn fork(state: &mut State, _args: &[Value]) -> Value {
-    let cpid = state.pid + 1;
-    state.pid = cpid;
+    let cpid = state.uid + 1;
+    state.uid = cpid;
     let pid = state.bv(format!("pid_{}", cpid).as_str(), 64);
     let a = pid
         ._eq(&state.bvv(cpid, 64))
@@ -314,7 +314,7 @@ pub fn fork(state: &mut State, _args: &[Value]) -> Value {
 }
 
 pub fn getpid(state: &mut State, _args: &[Value]) -> Value {
-    Value::Concrete(state.pid, 0)
+    Value::Concrete(state.uid, 0)
 }
 
 pub fn getuid(_state: &mut State, _args: &[Value]) -> Value {

--- a/radius/src/solver.rs
+++ b/radius/src/solver.rs
@@ -16,6 +16,12 @@ pub struct Solver {
     pub eval_max: usize,
 }
 
+impl Solver {
+    pub fn print_solver_ptr(&self) {
+        println!("Solver at: {:x}", Arc::as_ptr(&self.btor) as u64);
+    }
+}
+
 impl Default for Solver {
     fn default() -> Self {
         Self::new(EVAL_MAX)

--- a/radius/src/value.rs
+++ b/radius/src/value.rs
@@ -813,7 +813,7 @@ impl Value {
     }
 }
 
-/// convenience method for making an untainted `Value::Concrete`
+/// Convenience method for making an untainted [`Value::Concrete`].
 #[inline]
 pub fn vc(v: u64) -> Value {
     Value::Concrete(v, 0)


### PR DESCRIPTION
I recently had the need for a symbolic execution engine with nice Rust bindings (or even better, written in Rust) and MIPS support. The first thing worked out well here, the second thing required a bit of work, but it now works nicely :)

The main problem with MIPS support was handling of delay slots. I decided to handle them using the existing (but by default disabled) explicit delay-slot related operations in ESIL strings. See for details on my changes on the radare side https://github.com/radareorg/radare2/pull/23307. The other thing was putting the right return address in the backtrace, but this works nicely since the `fail` address is already delay slot aware. Note that the handling of delay slots is __incomplete__, in the sense that "likely" instructions are __not__ handled correctly. Those instructions only execute the delay slot if the branch is taken. It should be straight forward to do this properly by changing the ESIL of those instructions to
```
...,?{,"addr", SETJT, 1, SETD}{4,pc,+,pc,:=}
```
Also note that currently only a single delay slot is supported. Extending the code to multiple delay slots should be straight forward as well, e.g., by making `delay` a counter.

However, this patch is everything but clean, thus only a draft PR. Mostly for reference (on what to do do, or not to do) if you, or any other contributor, ever want to add delay slot support. The main blockers are:
- I am quite opinionated about __conditional symbolic values__ -- I thoroughly hate them :) -- and thus I removed them completely. IMHO this makes the code much simpler without any drawbacks, THB I think those values should not exist in symbolic states in the first place, it breaks the whole idea of a symbolic state corresponding to an equivalence class of concrete executions that go down a __single__ path. In fact, without this change I would not have known how to implement delay slots without incredibly awkward code.
- I broke a bunch of features related to stuff that I did not need for my use-case (which was UC symex on bare metal firmware). Those should be easy to fix.
- I added a hack to duplicate the solver on each fork of a state. This was needed since else `boolector` would abort if two states independently created the same symbolic memory. Since I also don't found a way to check if a variable already exists in a solver (`boolector` would just abort if it doesn't ...?!?! ... it would probably be an easy change on their side to provide such a method) I introduced this ugly inefficiency.

There are some other things, like adding doc comments, renaming things in a (IMO) descriptive way, which shouldn't me major problems though.

Thanks for creating this great project! If you want to add delay slot support I'd be happy to discuss my experience with you.

Cheers